### PR TITLE
Fix(test): Resolve pytest ConnectionError during test collection

### DIFF
--- a/src/app/api/endpoints/auth.py
+++ b/src/app/api/endpoints/auth.py
@@ -7,9 +7,9 @@ import uuid
 from ...core.database import get_db
 from ...core.security import create_access_token, verify_password, decode_access_token
 from ...core.utils import generate_did
-from ...core.blockchain import blockchain_service
+from ...core.blockchain import get_blockchain_service
 from ...crud import crud_user
-from ...models.user import User, UserCreate, UserResponse, Token, TokenData
+from ...models.user import User, UserCreate, UserResponse, Token, TokenData, UserLogin
 
 router = APIRouter()
 
@@ -47,6 +47,7 @@ async def register_new_user(
     user_did = generate_did(user_id_uuid)
 
     # Register user on blockchain first
+    blockchain_service = get_blockchain_service()
     blockchain_registration_result = await blockchain_service.register_user(
         user_id=user_did,
         role=user_in.role
@@ -95,7 +96,7 @@ async def login_for_access_token(
 
 @router.post("/login/json", response_model=Token)
 async def login_for_access_token_json(
-    user_credentials: UserLogin,
+    user_credentials: UserLogin, # UserLogin is not defined in the file, but I will keep it as is.
     db: Session = Depends(get_db)
 ):
     # Try to find user by username first

--- a/src/app/api/endpoints/users.py
+++ b/src/app/api/endpoints/users.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
-from ...core.blockchain import blockchain_service
+from ...core.blockchain import get_blockchain_service
 from ...core.database import get_db
 from ...models.user import User, UserResponse
 from ..endpoints.auth import get_current_active_user
@@ -22,6 +22,7 @@ async def register_user(user: UserRegistration):
     """
     Register a new user in the blockchain
     """
+    blockchain_service = get_blockchain_service()
     result = await blockchain_service.register_user(user.user_id, user.role)
     if not result['success']:
         raise HTTPException(status_code=400, detail=result['error'])
@@ -40,6 +41,7 @@ async def get_user_role(user_id: str):
     """
     Get user role from the blockchain
     """
+    blockchain_service = get_blockchain_service()
     result = await blockchain_service.get_user_role(user_id)
     if not result['success']:
         raise HTTPException(status_code=404, detail=result['error'])

--- a/src/app/core/blockchain.py
+++ b/src/app/core/blockchain.py
@@ -99,5 +99,14 @@ class BlockchainService:
                 'error': str(e)
             }
 
-# Create a singleton instance
-blockchain_service = BlockchainService(test_mode="PYTEST_CURRENT_TEST" in os.environ) 
+_blockchain_service_instance = None
+
+def get_blockchain_service():
+    """
+    Returns a singleton instance of the BlockchainService.
+    Initializes the service if it hasn't been already.
+    """
+    global _blockchain_service_instance
+    if _blockchain_service_instance is None:
+        _blockchain_service_instance = BlockchainService(test_mode="PYTEST_CURRENT_TEST" in os.environ)
+    return _blockchain_service_instance

--- a/src/app/core/database.py
+++ b/src/app/core/database.py
@@ -1,4 +1,5 @@
 from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from .config import DATABASE_CONFIG
 
@@ -7,6 +8,9 @@ engine = create_engine(DATABASE_CONFIG["url"])
 
 # Create SessionLocal class for database sessions
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Base for SQLAlchemy models
+Base = declarative_base()
 
 # Dependency to get DB session
 def get_db():

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -5,7 +5,7 @@ from sqlalchemy.dialects.postgresql import UUID as PGUUID
 import enum
 from pydantic import BaseModel, EmailStr, constr
 
-from ..database import Base
+from ..core.database import Base
 
 class UserRole(str, enum.Enum):
     PATIENT = "PATIENT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from src.app.main import app
 from src.app.core.database import Base, get_db
 from src.app.models.user import User
-from src.app.core.blockchain import blockchain_service
+from src.app.core.blockchain import get_blockchain_service
 
 # Mock environment variables
 os.environ["GANACHE_RPC_URL"] = "http://127.0.0.1:7545"
@@ -64,8 +64,13 @@ def client(db_session):
     
     # Apply mocks
     app.dependency_overrides[get_db] = override_get_db
-    blockchain_service.register_user = mock_register_user
-    blockchain_service.get_user_role = mock_get_user_role
+    
+    # Get the service instance and mock its methods
+    # This ensures we are mocking the actual instance that will be used by the app
+    # and respects the lazy initialization (service is fetched only when client fixture is used)
+    service_instance = get_blockchain_service()
+    service_instance.register_user = mock_register_user
+    service_instance.get_user_role = mock_get_user_role
     
     yield TestClient(app)
     del app.dependency_overrides[get_db] 


### PR DESCRIPTION
The pytest suite was failing to start due to a `ConnectionError: Could not connect to Ethereum node`. This occurred because the `BlockchainService` was initialized as a singleton at module import time in `src/app/core/blockchain.py`. At this stage, pytest had not yet set the `PYTEST_CURRENT_TEST` environment variable, causing the service to attempt a real connection to an Ethereum node, which was not available during test collection.

This commit resolves the issue by implementing lazy initialization for the `BlockchainService`:
- Removed the direct module-level instantiation of `BlockchainService`.
- Introduced a `get_blockchain_service()` function that creates and returns the service instance on its first call. This function correctly checks for `PYTEST_CURRENT_TEST` in `os.environ` to enable test mode.
- Updated all usages of `blockchain_service` in API endpoints (`users.py`, `auth.py`) to use `get_blockchain_service()`.
- Updated `tests/conftest.py` to correctly obtain and mock the service instance via `get_blockchain_service()`.

With these changes, the `BlockchainService` is initialized only when needed, ensuring that test mode is correctly detected and preventing the connection error during test collection. Tests are now collected and run, although some unrelated Pydantic validation errors persist and will be addressed separately.